### PR TITLE
Subtle changes (plot example, add here) and eval

### DIFF
--- a/manuscript/manuscript.Rmd
+++ b/manuscript/manuscript.Rmd
@@ -31,7 +31,7 @@ output            : papaja::apa6_word
 ```{r setup, include = FALSE}
 library("papaja")
 r_refs("r-references.bib")
-source("../scripts/libs.R")
+source(here::here("./scripts/libs.R"))
 ```
 
 ```{r analysis-preferences}

--- a/scripts/script.R
+++ b/scripts/script.R
@@ -83,6 +83,14 @@ plot_accuracy <- data_tidy |>
     title = "Accuracy per Word Type by language",
     x = "Word Type", y = "Accuracy")
 
+data_tidy |> 
+  group_by(id, language, word_type) |> 
+  summarize(response = mean(accuracy)) |> 
+  ggplot() + 
+  aes(x = language, y = response, color = word_type) + 
+  geom_point(position = position_dodge(0.5), alpha = 0.2) + 
+  stat_summary(fun.data = mean_sdl, geom = "pointrange", position = position_dodge(0.75)) 
+
 # save plot
 
 ggsave(


### PR DESCRIPTION
## Paper

- Wrong answers are coded as 0. 
That seems odd. 
- You probably mean the participants and items were random intercepts, not slopes. 
- Overall, the 'Statistical Analysis' subsection is pretty good, but always describe fixed effects first, then random effects (you mention the interaction after the 'random slopes')
- "For random effects, the accuracy model shows variability for participants (variance = 2.091e-02). This confirms that participants vary in their performance and allows the model to assign a different baseline for each one of them." As a general rule, just don't ever say "confirm". Very rarely do we ever confirm anything. Also, you would virtually always expect the variable from the random effects to be non-zero, so the sentence is kind of silly. Either way, regardless of the value of the variance component, the model is going to fit an intercept to each participant... because you coded it to do so. This sentence suggests it only happens because of some condition. 
- "In contrast, there is no variability for item (variance = 1.148e-09). This indicates almost no variance per item, so allowing each item to have its own slope might be unnecessary." You mean the random intercepts might not be necessary. Note, you lose nothing by including them. 
- Re: the first plot, I think it is clear from the figure that including the standard deviation is not ideal (it is giving you impossible values). In cases like this, I would opt for the standard error. Another option is to calculate the average by participant in each condition and then plot that (see lines 86-92 in my PR). 
- Same comments as above regarding the latency model and random effects. 
- Re: the second plot, you only plotted the raw data. Not ideal. 
- Your write-up doesn't say anything about model assumptions. 


## Project/Repo/Reproducibility

- The structure of the project looks great
- The manuscript is reproducible, but the code cannot be run from the script (without modifying it). You should use the 'here' package everywhere (not just in the R scripts) to avoid this (e.g., line 34 of manuscript.Rmd). 
- What's the point of sourcing 'libs.R' in line 10 if you just load all the packages in lines 1-8?

## Peer review

- Alex ✅ 
- Jukun ✅ 